### PR TITLE
feat: simplify test setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Test
-        run: make test
+        run: make test-integration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,4 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Test
-        env:
-            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            AWS_REGION: ${{ secrets.AWS_REGION }}
-            AWS_MESSAGE_DELAY: ${{ secrets.AWS_MESSAGE_DELAY }}
-            AWS_VISIBILITY: ${{ secrets.AWS_VISIBILITY }}
         run: make test

--- a/.github/workflows/validate-generated-files.yml
+++ b/.github/workflows/validate-generated-files.yml
@@ -1,0 +1,23 @@
+name: validate-generated-files
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  validate-generated-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Check generated files
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          make install-tools generate
+          git diff --exit-code --numstat

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ build:
 test:
 	go test $(GOTEST_FLAGS) -race -v ./...
 
+test-integration: up
+	go test $(GOTEST_FLAGS) -v -race ./...; ret=$$?; \
+		docker compose -f test/docker-compose.yml down -v; \
+		exit $$ret
+
 .PHONY: lint
 lint:
 	golangci-lint run
@@ -17,3 +22,11 @@ install-tools:
 	@echo Installing tools from tools.go
 	@go list -e -f '{{ join .Imports "\n" }}' tools.go | xargs -I % go list -f "%@{{.Module.Version}}" % | xargs -tI % go install %
 	@go mod tidy
+
+.PHONY: up
+up:
+	docker compose -f test/docker-compose.yml up --quiet-pull -d --wait 
+
+.PHONY: down
+down:
+	docker compose -f test/docker-compose.yml down -v --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ test-integration: up
 		docker compose -f test/docker-compose.yml down -v; \
 		exit $$ret
 
+.PHONY: generate
+generate:
+	go generate ./...
+
 .PHONY: lint
 lint:
 	golangci-lint run

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The configuration passed to `Configure` can contain the following fields:
 | `aws.region`          | AWS SQS Region                                 | yes      | "us-east-1"         |
 | `aws.queue`           | AWS SQS Queue Name                             | yes      | "QUEUE_NAME"        |
 | `aws.delayTime`       | AWS SQS Message Delay                          | yes      | "5"                 |
-| `aws.url`             | AWSURL is the URL for AWS (internal use only). | no       |                     |
+| `aws.url`             | URL for AWS (internal use only)  | no       |                     |
 
 #### Destination
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,41 @@
-# Conduit Connector for Amazon SQS 
+# Conduit Connector for Amazon SQS
+
 [Conduit](https://conduit.io) for [Amazon SQS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/welcome.html).
 
 ## How to build?
-Run `make build` to build the connector.
 
+Run `make build` to build the connector.
 
 ## Source
 
-
 The source connector pulls data from the Amazon SQS Queue. As messages come in, the source connector grabs a single message from the Amazon SQS Queue, formats it for the destination connector as a new record, and sends it. The Message Body of the SQS Message is formatted into a record's payload, and the Message Attributes are passed as record metadata. After the record has been acknowledged, the source connector deletes the message from the Amazon SQS Queue.
-
 
 ## Destinaton
 
-
 The destination connector batches incoming records into 10 and pushes them to the Amazon SQS Queue. Any fields defined in the metadata of the record will be passed as Message Attributes, and the json encoding of the record will be passed as the Message Body.
-
 
 ### Configuration
 
-
 The configuration passed to `Configure` can contain the following fields:
 
-#### Source 
+#### Source
 
-| name                  | description                                                                           | required | example             |
-| --------------------- | ------------------------------------------------------------------------------------- | -------- | ------------------- |
-| `aws.accessKeyId`     | AWS Access Key ID                                                                     | yes      | "THE_ACCESS_KEY_ID" |
-| `aws.secretAccessKey` | AWS Secret Access Key                                                                 | yes      | "SECRET_ACCESS_KEY" |
-| `aws.region`          | AWS SQS Region                                                                        | yes      | "us-east-1"         |
-| `aws.queue`           | AWS SQS Queue Name                                                                    | yes      | "QUEUE_NAME"        |
-| `aws.delayTime`       | AWS SQS Message Delay                                                                 | yes      | "5"                 | 
+| name                  | description                                    | required | example             |
+| --------------------- | ---------------------------------------------- | -------- | ------------------- |
+| `aws.accessKeyId`     | AWS Access Key ID                              | yes      | "THE_ACCESS_KEY_ID" |
+| `aws.secretAccessKey` | AWS Secret Access Key                          | yes      | "SECRET_ACCESS_KEY" |
+| `aws.region`          | AWS SQS Region                                 | yes      | "us-east-1"         |
+| `aws.queue`           | AWS SQS Queue Name                             | yes      | "QUEUE_NAME"        |
+| `aws.delayTime`       | AWS SQS Message Delay                          | yes      | "5"                 |
+| `aws.url`             | AWSURL is the URL for AWS (internal use only). | no       |                     |
 
 #### Destination
 
-| name                              | description                                                                           | required | example             |
-| --------------------------------- | ------------------------------------------------------------------------------------- | -------- | ------------------- |
-| `aws.accessKeyId`                 | AWS Access Key ID                                                                     | yes      | "THE_ACCESS_KEY_ID" |
-| `aws.secretAccessKey`             | AWS Secret Access Key                                                                 | yes      | "SECRET_ACCESS_KEY" |
-| `aws.region`                      | AWS SQS Region                                                                        | yes      | "us-east-1"         |
-| `aws.queue`                       | AWS SQS Queue Name                                                                    | yes      | "QUEUE_NAME"        |
-| `aws.visibilityTimeout`           | AWS SQS Message Visibility Timeout                                                    | yes      | "5"                 |
+| name                    | description                                    | required | example             |
+| ----------------------- | ---------------------------------------------- | -------- | ------------------- |
+| `aws.accessKeyId`       | AWS Access Key ID                              | yes      | "THE_ACCESS_KEY_ID" |
+| `aws.secretAccessKey`   | AWS Secret Access Key                          | yes      | "SECRET_ACCESS_KEY" |
+| `aws.region`            | AWS SQS Region                                 | yes      | "us-east-1"         |
+| `aws.queue`             | AWS SQS Queue Name                             | yes      | "QUEUE_NAME"        |
+| `aws.visibilityTimeout` | AWS SQS Message Visibility Timeout             | yes      | "5"                 |
+| `aws.url`               | AWSURL is the URL for AWS (internal use only). | no       |                     |

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ The configuration passed to `Configure` can contain the following fields:
 | `aws.region`            | AWS SQS Region                                 | yes      | "us-east-1"         |
 | `aws.queue`             | AWS SQS Queue Name                             | yes      | "QUEUE_NAME"        |
 | `aws.visibilityTimeout` | AWS SQS Message Visibility Timeout             | yes      | "5"                 |
-| `aws.url`               | AWSURL is the URL for AWS (internal use only). | no       |                     |
+| `aws.url`               | URL for AWS (internal use only)  | no       |                     |

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/config.go
+++ b/common/config.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/config.go
+++ b/common/config.go
@@ -15,15 +15,15 @@
 package common
 
 type Config struct {
-	// amazon access key id
+	// AWSAccessKeyID is the amazon access key id
 	AWSAccessKeyID string `json:"aws.accessKeyId" validate:"required"`
-	// amazon secret access key
+	// AWSSecretAccessKey is the amazon secret access key
 	AWSSecretAccessKey string `json:"aws.secretAccessKey" validate:"required"`
-	// amazon sqs region
+	// AWSRegion is the amazon sqs region
 	AWSRegion string `json:"aws.region" validate:"required"`
-	// amazon sqs queue name
+	// AWSQueue is the sqs queue name
 	AWSQueue string `json:"aws.queue" validate:"required"`
-	// AWSURL is the URL for endpoint override - testing/dry-run only
+	// AWSURL is the URL for AWS (internal use only).
 	AWSURL string `json:"aws.url"`
 }
 

--- a/common/config.go
+++ b/common/config.go
@@ -23,6 +23,8 @@ type Config struct {
 	AWSRegion string `json:"aws.region" validate:"required"`
 	// amazon sqs queue name
 	AWSQueue string `json:"aws.queue" validate:"required"`
+	// AWSURL is the URL for endpoint override - testing/dry-run only
+	AWSURL string `json:"aws.url"`
 }
 
 const (
@@ -33,4 +35,6 @@ const (
 	ConfigKeyAWSRegion = "aws.region"
 
 	ConfigKeyAWSQueue = "aws.queue"
+
+	ConfigKeyAWSURL = "aws.url"
 )

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,10 +1,10 @@
-// Copyright © 2024 Meroxa, Inc.
+// Copyright © 2023 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	transport "github.com/aws/smithy-go/endpoints"
 )
@@ -40,4 +42,30 @@ func (e *EndpointResolver) ResolveEndpoint(
 	_ sqs.EndpointParameters,
 ) (transport.Endpoint, error) {
 	return transport.Endpoint{URI: e.url}, nil
+}
+
+func NewSQSClient(ctx context.Context, cfg Config) (*sqs.Client, error) {
+	sqsCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(cfg.AWSRegion),
+		config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(
+				cfg.AWSAccessKeyID,
+				cfg.AWSSecretAccessKey,
+				"")),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load aws config with given credentials: %w", err)
+	}
+
+	var sqsOptions []func(*sqs.Options)
+	if url := cfg.AWSURL; url != "" {
+		endpointResolver, err := NewEndpointResolver(url)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create endpoint resolver: %w", err)
+		}
+
+		sqsOptions = append(sqsOptions, sqs.WithEndpointResolverV2(endpointResolver))
+	}
+
+	return sqs.NewFromConfig(sqsCfg, sqsOptions...), nil
 }

--- a/common/utils.go
+++ b/common/utils.go
@@ -25,7 +25,7 @@ import (
 	transport "github.com/aws/smithy-go/endpoints"
 )
 
-// EndpointResolver sets a custom endpoint for the kinesis client. It satisfies the
+// EndpointResolver sets a custom endpoint for the sqs client. It satisfies the
 // sqs.EndpointResolverV2 interface.
 type EndpointResolver struct{ url url.URL }
 

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,0 +1,43 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	transport "github.com/aws/smithy-go/endpoints"
+)
+
+// EndpointResolver sets a custom endpoint for the kinesis client. It satisfies the
+// sqs.EndpointResolverV2 interface.
+type EndpointResolver struct{ url url.URL }
+
+func NewEndpointResolver(urlStr string) (sqs.EndpointResolverV2, error) {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse endpoint url: %w", err)
+	}
+	return &EndpointResolver{*u}, nil
+}
+
+func (e *EndpointResolver) ResolveEndpoint(
+	_ context.Context,
+	_ sqs.EndpointParameters,
+) (transport.Endpoint, error) {
+	return transport.Endpoint{URI: e.url}, nil
+}

--- a/connector.go
+++ b/connector.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/destination/config.go
+++ b/destination/config.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/destination/config_paramgen.go
+++ b/destination/config_paramgen.go
@@ -11,7 +11,7 @@ func (Config) Parameters() map[string]sdk.Parameter {
 	return map[string]sdk.Parameter{
 		"aws.accessKeyId": {
 			Default:     "",
-			Description: "amazon access key id",
+			Description: "aws.accessKeyId is the amazon access key id",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},
@@ -25,7 +25,7 @@ func (Config) Parameters() map[string]sdk.Parameter {
 		},
 		"aws.queue": {
 			Default:     "",
-			Description: "amazon sqs queue name",
+			Description: "aws.queue is the sqs queue name",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},
@@ -33,7 +33,7 @@ func (Config) Parameters() map[string]sdk.Parameter {
 		},
 		"aws.region": {
 			Default:     "",
-			Description: "amazon sqs region",
+			Description: "aws.region is the amazon sqs region",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},
@@ -41,7 +41,7 @@ func (Config) Parameters() map[string]sdk.Parameter {
 		},
 		"aws.secretAccessKey": {
 			Default:     "",
-			Description: "amazon secret access key",
+			Description: "aws.secretAccessKey is the amazon secret access key",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},
@@ -49,7 +49,7 @@ func (Config) Parameters() map[string]sdk.Parameter {
 		},
 		"aws.url": {
 			Default:     "",
-			Description: "aws.url is the URL for endpoint override - testing/dry-run only",
+			Description: "aws.url is the URL for AWS (internal use only).",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{},
 		},

--- a/destination/config_paramgen.go
+++ b/destination/config_paramgen.go
@@ -47,5 +47,11 @@ func (Config) Parameters() map[string]sdk.Parameter {
 				sdk.ValidationRequired{},
 			},
 		},
+		"aws.url": {
+			Default:     "",
+			Description: "aws.url is the URL for endpoint override - testing/dry-run only",
+			Type:        sdk.ParameterTypeString,
+			Validations: []sdk.Validation{},
+		},
 	}
 }

--- a/destination/config_test.go
+++ b/destination/config_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/destination/destination_integration_test.go
+++ b/destination/destination_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/destination/destination_integration_test.go
+++ b/destination/destination_integration_test.go
@@ -15,7 +15,6 @@
 package destination
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"strings"
@@ -44,14 +43,11 @@ type Data struct {
 
 func TestDestination_SuccessfulMessageSend(t *testing.T) {
 	is := is.New(t)
-	ctx := context.Background()
+	ctx := testutils.TestContext(t)
 
 	metadata := sdk.Metadata{}
 	destination := NewDestination()
-	defer func() {
-		err := destination.Teardown(ctx)
-		is.NoErr(err)
-	}()
+	defer func() { is.NoErr(destination.Teardown(ctx)) }()
 
 	messageBody := "Test message body"
 	record := sdk.Util.Source.NewRecordCreate(
@@ -98,7 +94,7 @@ func TestDestination_SuccessfulMessageSend(t *testing.T) {
 
 func TestDestination_FailBadRecord(t *testing.T) {
 	is := is.New(t)
-	ctx := context.Background()
+	ctx := testutils.TestContext(t)
 
 	testClient := testutils.NewSQSClient(ctx, is)
 	queueName := testutils.CreateTestQueue(ctx, t, is, testClient)
@@ -106,10 +102,7 @@ func TestDestination_FailBadRecord(t *testing.T) {
 
 	metadata := sdk.Metadata{}
 	destination := NewDestination()
-	defer func() {
-		err := destination.Teardown(ctx)
-		is.NoErr(err)
-	}()
+	defer func() { is.NoErr(destination.Teardown(ctx)) }()
 
 	messageBody := "Test message body"
 	record := sdk.Util.Source.NewRecordCreate(
@@ -131,15 +124,12 @@ func TestDestination_FailBadRecord(t *testing.T) {
 
 func TestDestination_FailNonExistentQueue(t *testing.T) {
 	is := is.New(t)
-	ctx := context.Background()
+	ctx := testutils.TestContext(t)
 
 	destination := NewDestination()
-	defer func() {
-		err := destination.Teardown(ctx)
-		is.NoErr(err)
-	}()
+	defer func() { is.NoErr(destination.Teardown(ctx)) }()
 
-	cfg := testutils.IntegrationConfig("testqueue")
+	cfg := testutils.IntegrationConfig("nonexistent-testqueue")
 
 	cfg[common.ConfigKeyAWSQueue] = ""
 

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.27
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.34.3
+	github.com/aws/smithy-go v1.20.3
 	github.com/conduitio/conduit-connector-sdk v0.9.1
 	github.com/golangci/golangci-lint v1.59.1
 	github.com/google/uuid v1.6.0
 	github.com/matryer/is v1.4.1
+	github.com/rs/zerolog v1.32.0
 	go.uber.org/mock v0.4.0
 )
 
@@ -45,7 +47,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.22.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.3 // indirect
-	github.com/aws/smithy-go v1.20.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bkielbasa/cyclop v1.2.1 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
@@ -161,7 +162,6 @@ require (
 	github.com/quasilyte/gogrep v0.5.0 // indirect
 	github.com/quasilyte/regex/syntax v0.0.0-20210819130434-b3f0c404a727 // indirect
 	github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 // indirect
-	github.com/rs/zerolog v1.32.0 // indirect
 	github.com/ryancurrah/gomodguard v1.3.2 // indirect
 	github.com/ryanrolds/sqlclosecheck v0.5.1 // indirect
 	github.com/sanposhiho/wastedassign/v2 v2.0.7 // indirect

--- a/source/config.go
+++ b/source/config.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/config_paramgen.go
+++ b/source/config_paramgen.go
@@ -11,7 +11,7 @@ func (Config) Parameters() map[string]sdk.Parameter {
 	return map[string]sdk.Parameter{
 		"aws.accessKeyId": {
 			Default:     "",
-			Description: "amazon access key id",
+			Description: "aws.accessKeyId is the amazon access key id",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},
@@ -19,7 +19,7 @@ func (Config) Parameters() map[string]sdk.Parameter {
 		},
 		"aws.queue": {
 			Default:     "",
-			Description: "amazon sqs queue name",
+			Description: "aws.queue is the sqs queue name",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},
@@ -27,7 +27,7 @@ func (Config) Parameters() map[string]sdk.Parameter {
 		},
 		"aws.region": {
 			Default:     "",
-			Description: "amazon sqs region",
+			Description: "aws.region is the amazon sqs region",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},
@@ -35,7 +35,7 @@ func (Config) Parameters() map[string]sdk.Parameter {
 		},
 		"aws.secretAccessKey": {
 			Default:     "",
-			Description: "amazon secret access key",
+			Description: "aws.secretAccessKey is the amazon secret access key",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{
 				sdk.ValidationRequired{},
@@ -43,7 +43,7 @@ func (Config) Parameters() map[string]sdk.Parameter {
 		},
 		"aws.url": {
 			Default:     "",
-			Description: "aws.url is the URL for endpoint override - testing/dry-run only",
+			Description: "aws.url is the URL for AWS (internal use only).",
 			Type:        sdk.ParameterTypeString,
 			Validations: []sdk.Validation{},
 		},

--- a/source/config_paramgen.go
+++ b/source/config_paramgen.go
@@ -41,6 +41,12 @@ func (Config) Parameters() map[string]sdk.Parameter {
 				sdk.ValidationRequired{},
 			},
 		},
+		"aws.url": {
+			Default:     "",
+			Description: "aws.url is the URL for endpoint override - testing/dry-run only",
+			Type:        sdk.ParameterTypeString,
+			Validations: []sdk.Validation{},
+		},
 		"aws.visibilityTimeout": {
 			Default:     "0",
 			Description: "visibility timeout",

--- a/source/config_test.go
+++ b/source/config_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/source.go
+++ b/source/source.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/source.go
+++ b/source/source.go
@@ -53,7 +53,7 @@ func (s *Source) Configure(ctx context.Context, cfg map[string]string) error {
 func (s *Source) Open(ctx context.Context, _ sdk.Position) (err error) {
 	s.svc, err = common.NewSQSClient(ctx, s.config.Config)
 	if err != nil {
-		return fmt.Errorf("failed to create sourcde sqs client: %w", err)
+		return fmt.Errorf("failed to create source sqs client: %w", err)
 	}
 
 	queueInput := &sqs.GetQueueUrlInput{

--- a/source/source_integration_test.go
+++ b/source/source_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/source_integration_test.go
+++ b/source/source_integration_test.go
@@ -29,10 +29,7 @@ func TestSource_SuccessfulMessageReceive(t *testing.T) {
 	is := is.New(t)
 	ctx := testutils.TestContext(t)
 	source := NewSource()
-	defer func() {
-		err := source.Teardown(ctx)
-		is.NoErr(err)
-	}()
+	defer func() { is.NoErr(source.Teardown(ctx)) }()
 
 	testClient := testutils.NewSQSClient(ctx, is)
 	testQueue := testutils.CreateTestQueue(ctx, t, is, testClient)
@@ -66,18 +63,13 @@ func TestSource_SuccessfulMessageReceive(t *testing.T) {
 	if err != sdk.ErrBackoffRetry || record.Metadata != nil {
 		t.Fatalf("expected no records and a signal that there are no more records, got %v %v", record, err)
 	}
-
-	is.NoErr(source.Teardown(ctx))
 }
 
 func TestSource_FailBadCreds(t *testing.T) {
 	is := is.New(t)
 	ctx := testutils.TestContext(t)
 	source := NewSource()
-	defer func() {
-		err := source.Teardown(ctx)
-		is.NoErr(err)
-	}()
+	defer func() { is.NoErr(source.Teardown(ctx)) }()
 
 	testClient := testutils.NewSQSClient(ctx, is)
 	testQueue := testutils.CreateTestQueue(ctx, t, is, testClient)

--- a/source/source_integration_test.go
+++ b/source/source_integration_test.go
@@ -67,7 +67,7 @@ func TestSource_SuccessfulMessageReceive(t *testing.T) {
 		t.Fatalf("expected no records and a signal that there are no more records, got %v %v", record, err)
 	}
 
-	_ = source.Teardown(ctx)
+	is.NoErr(source.Teardown(ctx))
 }
 
 func TestSource_FailBadCreds(t *testing.T) {

--- a/source/source_integration_test.go
+++ b/source/source_integration_test.go
@@ -15,37 +15,35 @@
 package source
 
 import (
-	"context"
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/conduitio-labs/conduit-connector-sqs/common"
+	testutils "github.com/conduitio-labs/conduit-connector-sqs/test"
 	sdk "github.com/conduitio/conduit-connector-sdk"
-	"github.com/google/uuid"
 	"github.com/matryer/is"
 )
 
 func TestSource_SuccessfulMessageReceive(t *testing.T) {
 	is := is.New(t)
-	ctx := context.Background()
+	ctx := testutils.TestContext(t)
 	source := NewSource()
 	defer func() {
 		err := source.Teardown(ctx)
 		is.NoErr(err)
 	}()
-	sourceQueue := "test-queue-source-" + uuid.NewString()
-	client, url, cfg, err := prepareIntegrationTest(t, sourceQueue)
-	is.NoErr(err)
+
+	testClient := testutils.NewSQSClient(ctx, is)
+	testQueue := testutils.CreateTestQueue(ctx, t, is, testClient)
+	cfg := testutils.IntegrationConfig(testQueue.Name)
 
 	messageBody := "Test message body"
-	_, err = client.SendMessage(
-		context.Background(),
+	_, err := testClient.SendMessage(
+		ctx,
 		&sqs.SendMessageInput{
 			MessageBody: &messageBody,
-			QueueUrl:    url.QueueUrl,
+			QueueUrl:    testQueue.URL,
 		},
 	)
 	is.NoErr(err)
@@ -71,21 +69,23 @@ func TestSource_SuccessfulMessageReceive(t *testing.T) {
 
 	_ = source.Teardown(ctx)
 }
+
 func TestSource_FailBadCreds(t *testing.T) {
 	is := is.New(t)
-	ctx := context.Background()
+	ctx := testutils.TestContext(t)
 	source := NewSource()
 	defer func() {
 		err := source.Teardown(ctx)
 		is.NoErr(err)
 	}()
-	sourceQueue := "test-queue-source-" + uuid.NewString()
-	_, _, cfg, err := prepareIntegrationTest(t, sourceQueue)
-	is.NoErr(err)
+
+	testClient := testutils.NewSQSClient(ctx, is)
+	testQueue := testutils.CreateTestQueue(ctx, t, is, testClient)
+	cfg := testutils.IntegrationConfig(testQueue.Name)
 
 	cfg[common.ConfigKeyAWSAccessKeyID] = ""
 
-	err = source.Configure(ctx, cfg)
+	err := source.Configure(ctx, cfg)
 	is.NoErr(err)
 
 	err = source.Open(ctx, nil)
@@ -94,17 +94,16 @@ func TestSource_FailBadCreds(t *testing.T) {
 
 func TestSource_EmptyQueue(t *testing.T) {
 	is := is.New(t)
-	sourceQueue := "test-queue-source-" + uuid.NewString()
-	_, _, cfg, err := prepareIntegrationTest(t, sourceQueue)
-	ctx := context.Background()
-	is.NoErr(err)
+	ctx := testutils.TestContext(t)
+
+	testClient := testutils.NewSQSClient(ctx, is)
+	testQueue := testutils.CreateTestQueue(ctx, t, is, testClient)
+	cfg := testutils.IntegrationConfig(testQueue.Name)
 
 	source := NewSource()
-	defer func() {
-		err := source.Teardown(ctx)
-		is.NoErr(err)
-	}()
-	err = source.Configure(ctx, cfg)
+	defer func() { is.NoErr(source.Teardown(ctx)) }()
+
+	err := source.Configure(ctx, cfg)
 	is.NoErr(err)
 
 	err = source.Open(ctx, nil)
@@ -114,97 +113,5 @@ func TestSource_EmptyQueue(t *testing.T) {
 
 	if err != sdk.ErrBackoffRetry || record.Metadata != nil {
 		t.Fatalf("expected no records and a signal that there are no more records, got %v %v", record, err)
-	}
-}
-
-func TestSource_FailEmptyQueueName(t *testing.T) {
-	is := is.New(t)
-	sourceQueue := ""
-	_, _, _, err := prepareIntegrationTest(t, sourceQueue)
-
-	is.True(strings.Contains(err.Error(), "Queue name cannot be empty"))
-}
-
-func prepareIntegrationTest(t *testing.T, sourceQueue string) (*sqs.Client, *sqs.GetQueueUrlOutput, map[string]string, error) {
-	cfg := integrationConfig()
-
-	client, err := newAWSClient(cfg)
-	if err != nil {
-		t.Fatalf("could not create S3 client: %v", err)
-	}
-
-	_, err = client.CreateQueue(context.Background(), &sqs.CreateQueueInput{
-		QueueName: &sourceQueue,
-	})
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	queueInput := &sqs.GetQueueUrlInput{
-		QueueName: &sourceQueue,
-	}
-	// Get URL of queue
-	urlResult, err := client.GetQueueUrl(context.Background(), queueInput)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	t.Cleanup(func() {
-		err := deleteSQSQueue(t, client, urlResult.QueueUrl)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	cfg[common.ConfigKeyAWSQueue] = sourceQueue
-
-	return client, urlResult, cfg, nil
-}
-
-func deleteSQSQueue(t *testing.T, svc *sqs.Client, url *string) error {
-	_, err := svc.DeleteQueue(context.Background(), &sqs.DeleteQueueInput{
-		QueueUrl: url,
-	})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func newAWSClient(cfg map[string]string) (*sqs.Client, error) {
-	awsConfig, err := config.LoadDefaultConfig(context.Background(),
-		config.WithRegion(cfg[common.ConfigKeyAWSRegion]),
-		config.WithCredentialsProvider(
-			credentials.NewStaticCredentialsProvider(
-				cfg[common.ConfigKeyAWSAccessKeyID],
-				cfg[common.ConfigKeyAWSSecretAccessKey],
-				""),
-		),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	var sqsOptions []func(*sqs.Options)
-	if url := cfg[common.ConfigKeyAWSURL]; url != "" {
-		endpointResolver, err := common.NewEndpointResolver(url)
-		if err != nil {
-			return nil, err
-		}
-
-		sqsOptions = append(sqsOptions, sqs.WithEndpointResolverV2(endpointResolver))
-	}
-
-	// Create a SQS client from just a session.
-	sqsClient := sqs.NewFromConfig(awsConfig, sqsOptions...)
-
-	return sqsClient, nil
-}
-
-func integrationConfig() map[string]string {
-	return map[string]string{
-		common.ConfigKeyAWSAccessKeyID:     "accessskeymock",
-		common.ConfigKeyAWSSecretAccessKey: "accessssecretmock",
-		common.ConfigKeyAWSRegion:          "us-east-1",
 	}
 }

--- a/spec.go
+++ b/spec.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  localstack:
+    container_name: "sqs"
+    image: localstack/localstack:3.6.0
+    ports:
+      - "4566:4566"
+    environment:
+      - DEBUG=1
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    healthcheck:
+      test: awslocal sqs list-queues
+      interval: 5s
+      timeout: 20s
+      retries: 6
+      start_period: 30s

--- a/test/utils.go
+++ b/test/utils.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Meroxa, Inc.
+// Copyright © 2024 Meroxa, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/utils.go
+++ b/test/utils.go
@@ -1,0 +1,89 @@
+// Copyright © 2023 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/conduitio-labs/conduit-connector-sqs/common"
+	"github.com/google/uuid"
+	"github.com/matryer/is"
+	"github.com/rs/zerolog"
+)
+
+func TestContext(t *testing.T) context.Context {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	return logger.WithContext(context.Background())
+}
+
+func NewSQSClient(ctx context.Context, is *is.I) *sqs.Client {
+	is.Helper()
+	client, err := common.NewSQSClient(ctx, common.Config{
+		AWSAccessKeyID:     "accessskeymock",
+		AWSSecretAccessKey: "accessssecretmock",
+		AWSRegion:          "us-east-1",
+		AWSURL:             "http://localhost:4566",
+	})
+	is.NoErr(err)
+
+	return client
+}
+
+type TestQueue struct {
+	Name string
+
+	// pointer string makes it easier to work with the aws sdk
+	URL *string
+}
+
+func CreateTestQueue(ctx context.Context, t *testing.T, is *is.I, client *sqs.Client) TestQueue {
+	is.Helper()
+	queueName := "test-queue-" + uuid.NewString()
+
+	_, err := client.CreateQueue(ctx, &sqs.CreateQueueInput{
+		QueueName: &queueName,
+	})
+	is.NoErr(err)
+
+	queueInput := &sqs.GetQueueUrlInput{
+		QueueName: &queueName,
+	}
+	urlResult, err := client.GetQueueUrl(ctx, queueInput)
+	is.NoErr(err)
+
+	t.Cleanup(func() {
+		_, err := client.DeleteQueue(ctx, &sqs.DeleteQueueInput{
+			QueueUrl: urlResult.QueueUrl,
+		})
+		is.NoErr(err)
+	})
+
+	return TestQueue{
+		Name: queueName,
+		URL:  urlResult.QueueUrl,
+	}
+}
+
+func IntegrationConfig(queueName string) map[string]string {
+	return map[string]string{
+		common.ConfigKeyAWSAccessKeyID:     "accessskeymock",
+		common.ConfigKeyAWSSecretAccessKey: "accessssecretmock",
+		common.ConfigKeyAWSRegion:          "us-east-1",
+		common.ConfigKeyAWSURL:             "http://localhost:4566",
+		common.ConfigKeyAWSQueue:           queueName,
+	}
+}


### PR DESCRIPTION
### Description

[Localstack](https://www.localstack.cloud/) is a very handy docker image that simulates most common aws services.
This pr adds an additional shared connector parameter, `aws.url`, which directs the aws sdk calls to the localstack instance, and it also sets up tests to use the image instead of a custom SQS instance.

We are using localstack for the [kinesis connector](https://github.com/conduitio-labs/conduit-connector-kinesis/), and acceptance tests pass reliably, so it is a solid tool to include.

Also there was a bit of duplicated test code in both the source and destination tests, this moves it to `test/utils.go`.

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-sqs/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.