### PR TITLE
fix: remove deprecated flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

Updates release workflow removing this deprecated flag.

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-sqs/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.